### PR TITLE
Fix create embeddings request data

### DIFF
--- a/src/modules/embeddings/operations/v1_embeddings_create.ts
+++ b/src/modules/embeddings/operations/v1_embeddings_create.ts
@@ -1,12 +1,12 @@
 import { AxiosRequestConfig } from "axios"
 import Prem from "$src/index"
-import type { operations } from "$types/api"
+import type { CreateEmbeddingRequest, CreateEmbeddingResponse } from "$types/index"
 
-export default (client: Prem) => (params: operations["v1_embeddings_create"]["requestBody"]["content"]["application/json"], options?: AxiosRequestConfig): Promise<operations["v1_embeddings_create"]["responses"]["200"]["content"]["application/json"]> => {
+export default (client: Prem) => (params: CreateEmbeddingRequest, options?: AxiosRequestConfig): Promise<CreateEmbeddingResponse> => {
   return client.call({
-    method: "post",
+    method: "POST",
     url: `/v1/embeddings`,
-    ...params,
+    data: params,
     ...options
   })
 }


### PR DESCRIPTION
The `create` method was broken because params should be set on `data` key.

This PR also change the types being used, which are simpler. But this is unrelated to the issue and can be reverted if you disagree.